### PR TITLE
Add skeleton for API Gateway and Lambda function to serve client page

### DIFF
--- a/aws/lambda_files/serve_client_fn.py
+++ b/aws/lambda_files/serve_client_fn.py
@@ -1,0 +1,3 @@
+
+def handler(event, context):
+    print("serve_client_fn")

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,6 +1,7 @@
 astroid==2.3.3
 attrs==19.3.0
 aws-cdk.assets==1.22.0
+aws-cdk.aws-apigateway==1.22.0
 aws-cdk.aws-cloudwatch==1.22.0
 aws-cdk.aws-cognito==1.22.0
 aws-cdk.aws-ec2==1.22.0


### PR DESCRIPTION
This PR adds an API Gateway to the CDK app for serving the initial web application (and eventually other things). This includes:

* A Lambda-based API Gateway
* A dummy function for serving the page
* A helper function in the stack app for discovering lambda functions in files