### PR TITLE
Aws/webserver complete

### DIFF
--- a/aws/app.py
+++ b/aws/app.py
@@ -3,9 +3,12 @@ import yaml
 
 from aws_cdk import (
     aws_apigateway as apigateway,
+    aws_certificatemanager as cert_mgr,
     aws_cognito as cognito,
     aws_iam as iam,
     aws_lambda,
+    aws_route53 as route53,
+    aws_route53_targets as r53_targets,
     aws_s3 as s3,
     core
 )
@@ -34,6 +37,19 @@ class LunarRocksStack(core.Stack):
         super().__init__(app, id, **kwargs)
 
         config = load_config(CONFIG_DIR)
+        stack_id = config['stack_id']
+
+        # S3 Bucket for Gateway to use
+        if config['prod']:
+            pages_bucket_name = config['pages_bucket']
+            pages_bucket = s3.Bucket.from_bucket_arn(self, "LunarRocksPagesBucketexists", 'arn:aws:s3:::' + pages_bucket_name)
+        else:
+            pages_bucket = s3.Bucket(
+                    self,
+                    stack_id + "PagesBucket",
+                    removal_policy=core.RemovalPolicy.DESTROY
+            )
+            pages_bucket_name = pages_bucket.bucket_name
 
         # Get various lambda function files
         lambda_files = discover_lambda_files_in_path(WORKING_DIR)
@@ -43,34 +59,54 @@ class LunarRocksStack(core.Stack):
             serve_client_fn = fh.read()
         web_server_handler = aws_lambda.Function(
                 self,
-                "ServeClientFn",
+                stack_id + "ServeClientFn",
                 code=aws_lambda.InlineCode(serve_client_fn),
                 handler="index.handler",
                 runtime=aws_lambda.Runtime.PYTHON_3_7,
-                description="Handler function for serving LR client page"
-                )
+                description="Handler function for serving LR client page",
+                environment = {
+                    "S3_BUCKET": pages_bucket_name
+                }
+        )
+        lambda_read_statement = iam.PolicyStatement(
+                actions=['s3:List*', 's3:Get*'],
+                principals=[web_server_handler.role],
+                resources=[pages_bucket.bucket_arn],
+        )
+        pages_bucket.add_to_resource_policy(lambda_read_statement)
+        pages_bucket.grant_read(web_server_handler)
+        domain_cert = cert_mgr.Certificate(
+                self,
+                stack_id + "DomainCert",
+                domain_name=config['domain_name'],
+        )
+        gateway_domain = apigateway.DomainNameOptions(
+                certificate=domain_cert,
+                domain_name=config['domain_name'],
+        )
+        dns_hosted_zone = route53.HostedZone(
+                self,
+                stack_id + "HostedZone",
+                zone_name=config['domain_name'],
+        )
         web_api = apigateway.LambdaRestApi(
                 self,
-                'LambdaRestApi',
-                handler=web_server_handler)
-
-        # S3 Bucket for Gateway to use
-        removal_policy = core.RemovalPolicy.DESTROY
-        if config['prod']:
-            removal_policy = core.RemovalPolicy.RETAIN
-            user_object_store = s3.Bucket(
-                    self,
-                    "LunarRocksPagesBucket",
-                    bucket_name=config['pages_bucket'],
-                    removal_policy=removal_policy
-                    )
-        else:
-            user_object_store = s3.Bucket(
-                    self,
-                    "LunarRocksPagesBucket",
-                    removal_policy=remove
-                    )
-
+                stack_id + 'LambdaRestApi',
+                domain_name=gateway_domain,
+                handler=web_server_handler,
+                default_cors_preflight_options={
+                    "allow_origins": apigateway.Cors.ALL_ORIGINS,
+                    "allow_methods": ["GET"],
+                    "allow_headers": apigateway.Cors.DEFAULT_HEADERS
+                },
+        )
+        dns_record_set = route53.ARecord(
+                self,
+                stack_id + "RecordSet",
+                record_name=config['domain_name'],
+                target=route53.RecordTarget.from_alias(r53_targets.ApiGatewayDomain(web_api.domain_name)),
+                zone=dns_hosted_zone,
+        )
 
         # user pool and client provide auth for web app and API
         user_pool = cognito.CfnUserPool(
@@ -282,7 +318,7 @@ class LunarRocksStack(core.Stack):
         )
 
 
-
+config = load_config(CONFIG_DIR)
 app = core.App()
-stack = LunarRocksStack(app, "LunarRocksStack")
+stack = LunarRocksStack(app, config['stack_id'] + "Stack")
 app.synth()

--- a/aws/config/stack.yaml
+++ b/aws/config/stack.yaml
@@ -1,2 +1,4 @@
+domain_name: "moon-forge.com"
 pages_bucket: test-bucket-name
 prod: false
+stack_id: "LunarRocksTest"

--- a/aws/lambda_files/serve_client_fn.py
+++ b/aws/lambda_files/serve_client_fn.py
@@ -24,7 +24,7 @@ def handler(event, context):
         index_page = s3.get_object(Bucket=page_bucket_name, Key=index_target)
 
         return {
-          "body": json.dumps(index_page['Body'].read().decode('utf-8')),
+          "body": index_page['Body'].read().decode('utf-8'),
           "headers": {
             'content-type': "text/html",
           },

--- a/aws/lambda_files/serve_client_fn.py
+++ b/aws/lambda_files/serve_client_fn.py
@@ -1,3 +1,35 @@
+import boto3
+import json
+import os
+
+s3 = boto3.client('s3')
 
 def handler(event, context):
     print("serve_client_fn")
+    method = event['httpMethod']
+    page_bucket_name = os.environ['S3_BUCKET']
+
+    path = event.get('path', '')
+    widget_name = path.split('/')[1] if path.startswith('/') else path;
+
+    if method == "GET":
+      # GET / to get the index.html page
+      if path == "/":
+        # We grab the current file pointer first
+        # TODO: using a current file may not be necessary with versioned s3 bucket
+        current = s3.get_object(Bucket=page_bucket_name, Key='current.txt')
+        index_target = current['Body'].read().decode('utf-8').strip()
+        print(f'index target: {index_target}')
+
+        index_page = s3.get_object(Bucket=page_bucket_name, Key=index_target)
+
+        return {
+          "body": json.dumps(index_page['Body'].read().decode('utf-8')),
+          "headers": {
+            'content-type': "text/html",
+          },
+          "isBase64Encoded": False,
+          "statusCode": 200,
+        }
+
+

--- a/aws/readme.md
+++ b/aws/readme.md
@@ -26,10 +26,14 @@ pip install -r requirements.txt
 
 ### Configure
 
-Make sure you edit `config/stack.yaml` to include the correct
-configuration for your test or production stack. The file included
-in the repo is meant as an example only, to demonstrate the template
-the CDK app expects.
+* Local Config
+  * Make sure you edit `config/stack.yaml` to include the correct
+    configuration for your test or production stack. The file included
+    in the repo is meant as an example only, to demonstrate the template
+    the CDK app expects.
+* Domain Config
+  * You will need to configure your domain to use the custom nameservers
+    listed by AWS route53 rather than whatever default NS they might use
 
 ## Deploy
 

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -10,6 +10,8 @@ aws-cdk.aws-iam==1.22.0
 aws-cdk.aws-kms==1.22.0
 aws-cdk.aws-lambda==1.22.0
 aws-cdk.aws-logs==1.22.0
+aws-cdk.aws-route53==1.22.0
+aws-cdk.aws-route53-targets==1.22.0
 aws-cdk.aws-s3==1.22.0
 aws-cdk.aws-s3-assets==1.22.0
 aws-cdk.aws-sqs==1.22.0

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -25,12 +25,14 @@ botostubs==0.11.1.10.45
 cattrs==1.0.0
 Click==7.0
 docutils==0.15.2
+flake8==3.7.9
 importlib-resources==1.0.2
 isort==4.3.21
 jmespath==0.9.4
 jsii==0.21.2
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
+mypy==0.770
 publication==0.0.3
 pylint==2.4.4
 python-dateutil==2.8.1


### PR DESCRIPTION
This PR adds CDK config to stand up all the bits required for a Lambda/APIGateway web server to work, to include s3 bucket for the pages, the function and gateway themselves, and domain mapping.

This is noted in the readme, but depending on the developer's domain registrar (i.e. if the registrar is anyone but AWS), a manual step will be required to input custom NS records to point to AWS nameservers -- these records can be found in the AWS Route 53 Hosted Zone once the Stack has been stood up. NB that many registrars put the time to populate custom NS records at up to 48 hours, so tearing down/standing up stacks/hosted zones during development is not recommended.

Also note that this PR does not quite get the web server 100% working, as adjustments need to be made to the github action which builds the artifacts required by the client, as well as to the lambda and/or s3 bucket to allow serving static pages.